### PR TITLE
Remove the canApplyTogether method from Floral Feet

### DIFF
--- a/src/main/java/com/maideniles/maidensmaterials/enchants/EnchantmentFloralFeet.java
+++ b/src/main/java/com/maideniles/maidensmaterials/enchants/EnchantmentFloralFeet.java
@@ -53,22 +53,6 @@ public class EnchantmentFloralFeet extends Enchantment {
 	}
 		
 	@Override
-    public boolean canApplyTogether(Enchantment ench)
-    {
-        return super.canApplyTogether(ench) 
-               || ench == Enchantments.DEPTH_STRIDER 
-                || ench == Enchantments.FROST_WALKER
-                || ench == Enchantments.FEATHER_FALLING
-                || ench == Enchantments.PROTECTION
-                || ench == Enchantments.FIRE_PROTECTION
-                || ench == Enchantments.THORNS
-                || ench == Enchantments.MENDING
-        		|| ench == Enchantments.BLAST_PROTECTION;
-    }
-	
-	
-	
-	@Override
 	public boolean canApplyAtEnchantingTable(ItemStack stack) {
 		return canApply(stack);
 	}


### PR DESCRIPTION
The canApplyTogether would always return true as long as the enchant wasn't identical to the one being applied (in the super method).  This eliminates the override and simplifies the code as a result.